### PR TITLE
Enhancement #8

### DIFF
--- a/jmh.out
+++ b/jmh.out
@@ -1,8 +1,8 @@
-Benchmark                             Mode  Samples         Score  Score error  Units
-c.j.b.MapperBenchmark.dozer          thrpt      200     98039.808      259.717  ops/s
-c.j.b.MapperBenchmark.jmapper        thrpt      200  14213331.693    39890.865  ops/s
-c.j.b.MapperBenchmark.manual         thrpt      200  16466105.699    48380.688  ops/s
-c.j.b.MapperBenchmark.mapStruct      thrpt      200  14222424.755    26625.790  ops/s
-c.j.b.MapperBenchmark.modelMapper    thrpt      200    259133.143     1166.303  ops/s
-c.j.b.MapperBenchmark.orika          thrpt      200   3002845.492    13463.806  ops/s
-c.j.b.MapperBenchmark.selma          thrpt      200  15123857.330    28828.846  ops/s
+Benchmark                     Mode  Cnt         Score       Error  Units
+MapperBenchmark.dozer        thrpt  200     78140.203 ±   349.367  ops/s
+MapperBenchmark.jmapper      thrpt  200  13960300.134 ± 58236.670  ops/s
+MapperBenchmark.manual       thrpt  200  16449065.709 ± 53680.612  ops/s
+MapperBenchmark.mapStruct    thrpt  200  14237194.856 ± 51179.459  ops/s
+MapperBenchmark.modelMapper  thrpt  200    246365.253 ±  2019.151  ops/s
+MapperBenchmark.orika        thrpt  200   3014113.390 ± 14411.534  ops/s
+MapperBenchmark.selma        thrpt  200  15806337.820 ± 41094.339  ops/s

--- a/pom.xml
+++ b/pom.xml
@@ -14,15 +14,15 @@
     </prerequisites>
 
     <properties>
-        <version.orkika>1.4.6</version.orkika>
-        <version.dozer>5.3.2</version.dozer>
-        <version.modelmapper>0.7.5</version.modelmapper>
-        <version.mapstruct>1.0.0.CR2</version.mapstruct>
-        <version.selma>0.12</version.selma>
-        <version.jmapper>1.6.0</version.jmapper>
-        <version.jmh>1.0</version.jmh>
+        <version.orika>1.4.6</version.orika>
+        <version.dozer>5.5.1</version.dozer>
+        <version.modelmapper>0.7.6</version.modelmapper>
+        <version.mapstruct>1.0.0.Final</version.mapstruct>
+        <version.selma>0.15</version.selma>
+        <version.jmapper>1.6.0.1</version.jmapper>
+        <version.jmh>1.14</version.jmh>
         <version.junit>4.12</version.junit>
-        <version.slf4j>1.7.12</version.slf4j>
+        <version.slf4j>1.7.21</version.slf4j>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <javac.target>1.6</javac.target>
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>ma.glasnost.orika</groupId>
             <artifactId>orika-core</artifactId>
-            <version>${version.orkika}</version>
+            <version>${version.orika}</version>
         </dependency>
 
         <dependency>
@@ -65,18 +65,29 @@
             <artifactId>mapstruct</artifactId>
             <version>${version.mapstruct}</version>
         </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>${version.mapstruct}</version>
+        </dependency>
 
         <dependency>
             <groupId>fr.xebia.extras</groupId>
             <artifactId>selma</artifactId>
             <version>${version.selma}</version>
         </dependency>
+        <dependency>
+            <groupId>fr.xebia.extras</groupId>
+            <artifactId>selma-processor</artifactId>
+            <version>${version.selma}</version>
+            <scope>provided</scope>
+        </dependency>
          
         <dependency>
-		    <groupId>com.googlecode.jmapper-framework</groupId>
-		    <artifactId>jmapper-core</artifactId>
-		    <version>${version.jmapper}</version>
-		</dependency>
+            <groupId>com.googlecode.jmapper-framework</groupId>
+            <artifactId>jmapper-core</artifactId>
+            <version>${version.jmapper}</version>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>
@@ -90,8 +101,6 @@
             <artifactId>slf4j-nop</artifactId>
             <version>${version.slf4j}</version>
         </dependency>
-
-
     </dependencies>
 
     <build>
@@ -124,45 +133,23 @@
                                     <mainClass>org.openjdk.jmh.Main</mainClass>
                                 </transformer>
                             </transformers>
+                            <filters>
+                                <filter>
+                                    <!--
+                                        Shading signed JARs will fail without this.
+                                        http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                                    -->
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.bsc.maven</groupId>
-                <artifactId>maven-processor-plugin</artifactId>
-                <version>2.2.3</version>
-                <configuration>
-                    <defaultOutputDirectory>
-                        ${project.build.directory}/generated-sources
-                    </defaultOutputDirectory>
-                    <processors>
-                        <processor>org.mapstruct.ap.MappingProcessor</processor>
-                        <processor>fr.xebia.extras.selma.codegen.MapperProcessor</processor>
-                    </processors>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>process</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>process</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.mapstruct</groupId>
-                        <artifactId>mapstruct-processor</artifactId>
-                        <version>${version.mapstruct}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>fr.xebia.extras</groupId>
-                        <artifactId>selma-processor</artifactId>
-                        <version>${version.selma}</version>
-                    </dependency>
-                </dependencies>
             </plugin>
         </plugins>
         <pluginManagement>

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ Multi-layered applications often require to map between different object models 
 Writing such boiler plate mapping code is a tedious and error-prone task.
 A lot of object-to-object mapping Java frameworks aims to simplify this work and automate it.
 Some uses code instrospection (eg. Dozer). Other uses code generation (ex: MapStuct).
-This micro-benchmark compares performance of 5 frameworks. Results could be compared to the benchmark of a code written manually. 
+This micro-benchmark compares performance of 6 frameworks. Results could be compared to the benchmark of a code written manually. 
 
 Benchmark are powered by a tool called [JMH](http://openjdk.java.net/projects/code-tools/jmh/) or also known as "Java Microbenchmarking Harness".
 JMH is developed by the OpenJDK team. 
@@ -67,7 +67,7 @@ Tests has been performed on:
         <th>MapStruct</th><td>thrpt</td><td>200</td><td>14 237 194</td><td>51 179</td><td>ops/s</td>
     </tr>
     <tr>
-        <th>JMapper</th><td>thrpt</td><td>200</td><td>14 213 331</td><td>39 890</td><td>ops/s</td>
+        <th>JMapper</th><td>thrpt</td><td>200</td><td>13 960 300</td><td>58 236</td><td>ops/s</td>
     </tr>
     <tr>
         <th>Orika</th><td>thrpt</td><td>200</td><td>3 014 113</td><td>14 411</td><td>ops/s</td>

--- a/readme.md
+++ b/readme.md
@@ -58,31 +58,31 @@ Tests has been performed on:
         <th>Benchmark</th><th>Mode</th><th>Samples</th><th>Score</th><th>Margin error (+/-)</th><th>Units</th>
     </tr>
     <tr>
-        <th>Manual</th><td>thrpt</td><td>200</td><td>16 466 105</td><td>48 380</td><td>ops/s</td>
+        <th>Manual</th><td>thrpt</td><td>200</td><td>16 449 065</td><td>53 680</td><td>ops/s</td>
     </tr>
     <tr>
-        <th>Selma</th><td>thrpt</td><td>200</td><td>15 123 857</td><td>28 828</td><td>ops/s</td>
+        <th>Selma</th><td>thrpt</td><td>200</td><td>15 806 337</td><td>41 094</td><td>ops/s</td>
     </tr>
     <tr>        
-        <th>MapStruct</th><td>thrpt</td><td>200</td><td>14 222 424</td><td>26 625</td><td>ops/s</td>
+        <th>MapStruct</th><td>thrpt</td><td>200</td><td>14 237 194</td><td>51 179</td><td>ops/s</td>
     </tr>
     <tr>
         <th>JMapper</th><td>thrpt</td><td>200</td><td>14 213 331</td><td>39 890</td><td>ops/s</td>
     </tr>
     <tr>
-        <th>Orika</th><td>thrpt</td><td>200</td><td>3 002 845</td><td>13 463</td><td>ops/s</td>
+        <th>Orika</th><td>thrpt</td><td>200</td><td>3 014 113</td><td>14 411</td><td>ops/s</td>
     </tr>
     <tr>       
-        <th>ModelMaper</th><td>thrpt</td><td>200</td><td>259 133</td><td>1 166</td><td>ops/s</td>
+        <th>ModelMaper</th><td>thrpt</td><td>200</td><td>246 365</td><td>2 019</td><td>ops/s</td>
     </tr>
     <tr>
-        <th>Dozer</th><td>thrpt</td><td>200</td><td>98 039</td><td>259</td><td>ops/s</td>
+        <th>Dozer</th><td>thrpt</td><td>200</td><td>78 140</td><td>349</td><td>ops/s</td>
     </tr>
 </table>
 
 Legend : Higher score is better
 
-Total time: 00:58:05
+Total time: 00:48:33
 
 ## Documentation ##
 


### PR DESCRIPTION
Update libraries versions:
JMH 1.0 -> 1.14
Dozer 5.3.2 -> 5.5.1
ModelMapper 0.7.5 -> 0.7.6
MapStruct 1.0.0.CR2 -> 1.0.0.Final
Selma 0.12 -> 0.15
JMapper 1.6.0 -> 1.6.0.1

Other changes in the POM-file correspond to new jmh archetype version:
jmh-java-benchmark-archetype:1.14.