### PR TITLE
Remove duplicated mapping for billingAddress.stree

### DIFF
--- a/src/main/java/com/javaetmoi/benchmark/mapping/mapper/selma/SelmaOrderMapper.java
+++ b/src/main/java/com/javaetmoi/benchmark/mapping/mapper/selma/SelmaOrderMapper.java
@@ -13,9 +13,7 @@ import fr.xebia.extras.selma.Mapper;
                 @Field({"customer.billingAddress.street", "billingStreetAddress"}),
                 @Field({"customer.billingAddress.city", "billingCity"}),
                 @Field({"customer.shippingAddress.street", "shippingStreetAddress"}),
-                @Field({"customer.shippingAddress.city", "shippingCity"}),
-                @Field({"customer.billingAddress.street", "billingStreetAddress"}),
-                @Field({"customer.billingAddress.street", "billingStreetAddress"})
+                @Field({"customer.shippingAddress.city", "shippingCity"}))
         }
 )
 public interface SelmaOrderMapper {


### PR DESCRIPTION
Mapping for:
@Field({"customer.billingAddress.street", "billingStreetAddress"})

was defined 3 times.