### PR TITLE
Run apt-get update before installing gnuplot

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,9 @@ jobs:
           path: results.csv
       - shell: bash
         name: Install gnuplot
-        run: sudo apt-get install gnuplot
+        run: |
+          sudo apt-get update
+          sudo apt-get install gnuplot
       - shell: bash
         name: Plot Results
         run: |


### PR DESCRIPTION
This makes sure that the apt-get is updated before installing gnuplot and solves the problem when sometimes gnuplot cannot be installed